### PR TITLE
Add PF form wrapper, next/back callbacks and disable next/back functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formik-pf",
-  "version": "0.0.1-alpha6",
+  "version": "0.0.1-alpha7",
   "description": "A UI library that provides formik bindings with PF components.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formik-pf",
-  "version": "0.0.1-alpha5",
+  "version": "0.0.1-alpha6",
   "description": "A UI library that provides formik bindings with PF components.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/FormikWizard/FormikWizard.tsx
+++ b/src/components/FormikWizard/FormikWizard.tsx
@@ -18,14 +18,24 @@ export type FormikWizardStep = {
   validateOnBlur?: boolean;
   /** Tells Formik to validate upon mount */
   validateOnMount?: boolean;
-  /** Can change the Next button text. If nextButtonText is also set for the Wizard, this step specific one overrides it. */
+  /** (Unused if footer is controlled) The Next button text */
   nextButtonText?: React.ReactNode;
-  /** The condition needed to enable the Next button */
-  enableNext?: boolean;
+  /** (Unused if footer is controlled) The Back button text */
+  backButtonText?: React.ReactNode;
+  /** (Unused if footer is controlled) The Cancel button text */
+  cancelButtonText?: React.ReactNode;
+  /** (Unused if footer is controlled) The condition needed to disable the Next button */
+  disableNext?: boolean;
+  /** (Unused if footer is controlled) The condition needed to disable the Back button */
+  disableBack?: boolean;
   /** Enables or disables the step in the navigation. Enabled by default. */
   canJumpTo?: boolean;
   /** Removes the default body padding for the step. */
   hasNoBodyPadding?: boolean;
+  /** Sets the Form to horizontal. */
+  isFormHorizontal?: boolean;
+  /** Flag to limit the max-width to 500px. */
+  isFormWidthLimited?: boolean;
   /** Handler to be called before moving to next step */
   onSubmit?: (values: FormikValues, formikBag: FormikHelpers<FormikValues>) => Promise<any>;
 };
@@ -54,6 +64,7 @@ const FormikWizard: React.FunctionComponent<FormikWizardProps> = ({
   validateOnMount,
   onSubmit,
   onReset,
+  onNext,
   hasNoBodyPadding,
   ...restWizardProps
 }) => {
@@ -65,7 +76,7 @@ const FormikWizard: React.FunctionComponent<FormikWizardProps> = ({
   );
 
   const wizardConfig = useInternalWizard(initSteps, startAtStep);
-  const { currentStep, isLastStep, goNext } = wizardConfig;
+  const { currentStep, currentStepIndex, isLastStep, goNext } = wizardConfig;
 
   const handleSubmit = React.useCallback(
     async (values: FormikValues, formikHelpers: FormikHelpers<FormikValues>) => {
@@ -82,11 +93,13 @@ const FormikWizard: React.FunctionComponent<FormikWizardProps> = ({
       if (isLastStep) return onSubmit(values, formikHelpers);
 
       if (isValid) {
+        formikHelpers.setTouched({});
         setSnapshot(values);
+        onNext?.(currentStepIndex + 1, currentStepIndex);
         goNext();
       }
     },
-    [currentStep, isLastStep, onSubmit, goNext],
+    [currentStep, currentStepIndex, isLastStep, onSubmit, goNext, onNext],
   );
 
   return (

--- a/src/components/FormikWizard/InternalWizard.tsx
+++ b/src/components/FormikWizard/InternalWizard.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { WizardNav, WizardNavItem, WizardToggle, WizardProps } from '@patternfly/react-core';
 import styles from '@patternfly/react-styles/css/components/Wizard/wizard';
 import classNames from 'classnames';
+import { FormikValues, useFormikContext } from 'formik';
 import { FormikWizardStep } from './FormikWizard';
 import WizardFooter from './InternalWizardFooter';
 import { useInternalWizardContext } from './useInternalWizard';
@@ -36,8 +37,18 @@ const InternalWizard: React.FunctionComponent<InternalWizardProps> = ({
   navAriaLabel,
   navAriaLabelledBy,
 }) => {
-  const { currentStep, goToStep } = useInternalWizardContext();
+  const { currentStep, currentStepIndex, goToStep } = useInternalWizardContext();
+  const { setErrors, setStatus, isValid } = useFormikContext<FormikValues>();
   const [isNavOpen, setIsNavOpen] = React.useState(false);
+
+  const handleGoToStep = React.useCallback(
+    (stepIndex: number) => {
+      setErrors({});
+      setStatus({});
+      goToStep(stepIndex);
+    },
+    [goToStep, setErrors, setStatus],
+  );
 
   const nav = React.useCallback(
     (isWizardNavOpen: boolean) => {
@@ -54,16 +65,27 @@ const InternalWizard: React.FunctionComponent<InternalWizardProps> = ({
                 key={index}
                 content={step.name}
                 isCurrent={currentStep.name === step.name}
-                isDisabled={!step.canJumpTo && step.name !== currentStep.name}
+                isDisabled={
+                  (!step.canJumpTo || (!isValid && index > currentStepIndex)) &&
+                  step.name !== currentStep.name
+                }
                 step={steps.findIndex((s) => s.name === step.name)}
-                onNavItemClick={goToStep}
+                onNavItemClick={handleGoToStep}
               />
             );
           })}
         </WizardNav>
       );
     },
-    [currentStep.name, goToStep, navAriaLabel, navAriaLabelledBy, steps],
+    [
+      currentStep.name,
+      currentStepIndex,
+      handleGoToStep,
+      isValid,
+      navAriaLabel,
+      navAriaLabelledBy,
+      steps,
+    ],
   );
 
   return (

--- a/src/components/FormikWizard/InternalWizardFooter.tsx
+++ b/src/components/FormikWizard/InternalWizardFooter.tsx
@@ -15,30 +15,25 @@ type InternalWizardFooterProps = {
   nextButtonText?: React.ReactNode;
   backButtonText?: React.ReactNode;
   cancelButtonText?: React.ReactNode;
+  onBack?: (nextStepIndex: number, prevStepIndex: number) => void;
 };
 
 const InternalWizardFooter: React.FunctionComponent<InternalWizardFooterProps> = ({
   nextButtonText = 'Next',
   backButtonText = 'Back',
   cancelButtonText = 'Cancel',
+  onBack,
 }) => {
-  const { currentStep, isPrevDisabled, goBack } = useInternalWizardContext();
-  const {
-    isSubmitting,
-    isValidating,
-    isValid,
-    status,
-    setErrors,
-    setStatus,
-    submitForm,
-    handleReset,
-  } = useFormikContext<FormikValues>();
+  const { currentStepIndex, currentStep, isPrevDisabled, goBack } = useInternalWizardContext();
+  const { isSubmitting, isValidating, isValid, status, setErrors, setStatus } =
+    useFormikContext<FormikValues>();
 
   const handleBack = React.useCallback(() => {
     setErrors({});
     setStatus({});
+    onBack?.(currentStepIndex + 1, currentStepIndex);
     goBack();
-  }, [goBack, setErrors, setStatus]);
+  }, [currentStepIndex, goBack, onBack, setErrors, setStatus]);
 
   return (
     <footer
@@ -62,21 +57,31 @@ const InternalWizardFooter: React.FunctionComponent<InternalWizardFooterProps> =
           <Button
             variant="primary"
             type="submit"
-            isDisabled={isSubmitting || isValidating || status?.isValidating || !isValid}
+            isDisabled={
+              isSubmitting ||
+              isValidating ||
+              status?.isValidating ||
+              status?.submitError ||
+              !isValid ||
+              currentStep.disableNext
+            }
             isLoading={isSubmitting || isValidating || status?.isValidating}
-            onClick={submitForm}
           >
             {currentStep.nextButtonText || nextButtonText}
           </Button>
         </ActionListItem>
         <ActionListItem>
-          <Button variant="secondary" onClick={handleBack} isDisabled={isPrevDisabled}>
-            {backButtonText}
+          <Button
+            variant="secondary"
+            onClick={handleBack}
+            isDisabled={isPrevDisabled || currentStep.disableBack}
+          >
+            {currentStep.backButtonText || backButtonText}
           </Button>
         </ActionListItem>
         <ActionListItem>
-          <Button variant="link" onClick={handleReset}>
-            {cancelButtonText}
+          <Button variant="link" type="reset">
+            {currentStep.cancelButtonText || cancelButtonText}
           </Button>
         </ActionListItem>
       </ActionList>

--- a/src/components/FormikWizard/InternalWizardFooter.tsx
+++ b/src/components/FormikWizard/InternalWizardFooter.tsx
@@ -9,7 +9,6 @@ import {
 import styles from '@patternfly/react-styles/css/components/Wizard/wizard';
 import classNames from 'classnames';
 import { FormikValues, useFormikContext } from 'formik';
-import isEmpty from 'lodash/isEmpty';
 import { useInternalWizardContext } from './useInternalWizard';
 
 type InternalWizardFooterProps = {
@@ -27,9 +26,9 @@ const InternalWizardFooter: React.FunctionComponent<InternalWizardFooterProps> =
   const {
     isSubmitting,
     isValidating,
-    errors,
-    setErrors,
+    isValid,
     status,
+    setErrors,
     setStatus,
     submitForm,
     handleReset,
@@ -63,7 +62,7 @@ const InternalWizardFooter: React.FunctionComponent<InternalWizardFooterProps> =
           <Button
             variant="primary"
             type="submit"
-            isDisabled={isSubmitting || isValidating || status?.isValidating || !isEmpty(errors)}
+            isDisabled={isSubmitting || isValidating || status?.isValidating || !isValid}
             isLoading={isSubmitting || isValidating || status?.isValidating}
             onClick={submitForm}
           >


### PR DESCRIPTION
Fixes #13
Fixes #14
Fixes #15
Fixes #16   

This PR - 

- Updates the `canJumptTo` behaviour to mimic next/back functionality. A form with errors will disable `Next` button and all steps after the current one. 
- Adds a PF `Form` wrapper around all Wizard steps along with props to control the form wrapper for each step.
- Adds ability to change the `backButtonText` and `cancelButtonText` for each step.
- Adds ability to disable the next and back button for each step.
- Adds callback for `onNext` and `onBack`.
- Fixes the issue of all form fields being touched when moving to the next step.
- Disables the next button if there is a `status.submitError`.